### PR TITLE
restore ctrl-enter functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 2.6)
 
-project(linenoise)
+project(linenoise-ng)
 
 set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build")
 
@@ -76,15 +76,16 @@ include_directories(${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src)
 
 # build liblinenoise
 add_library(
-  linenoise
-  STATIC
+  linenoise-ng
+  SHARED
+#STATIC
   src/ConvertUTF.cpp
   src/linenoise.cpp
   src/wcwidth.cpp
 )
 
 # install
-install(TARGETS linenoise DESTINATION lib)
+install(TARGETS linenoise-ng DESTINATION lib)
 
 # headers
 install(FILES include/linenoise.h DESTINATION include)
@@ -97,7 +98,7 @@ add_executable(
 
 target_link_libraries(
   example
-  linenoise
+  linenoise-ng
 )
 
 # packaging
@@ -116,5 +117,5 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 
 set(CPACK_STRIP_FILES "ON")
 
-set(CPACK_PACKAGE_NAME "linenoise")
+set(CPACK_PACKAGE_NAME "linenoise-ng")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utilities")

--- a/src/linenoise.cpp
+++ b/src/linenoise.cpp
@@ -2554,7 +2554,7 @@ int InputBuffer::getInputLine(PromptBase& pi) {
                 killRing.lastAction = KillRing::actionKill;
                 break;
 
-            case ctrlChar('J'):  // ctrl-J/linefeed/newline, accept line
+            //case ctrlChar('J'):  // ctrl-J/linefeed/newline, accept line
             case ctrlChar('M'):  // ctrl-M/return/enter
                 killRing.lastAction = KillRing::actionOther;
                 // we need one last refresh with the cursor at the end of the line
@@ -2828,12 +2828,12 @@ int InputBuffer::getInputLine(PromptBase& pi) {
             default:
                 killRing.lastAction = KillRing::actionOther;
                 historyRecallMostRecent = false;
-                if (c & (META | CTRL)) {  // beep on unknown Ctrl and/or Meta keys
+                if (c & (META | CTRL) && !(c==ctrlChar('J'))) {  // beep on unknown Ctrl and/or Meta keys
                     beep();
                     break;
                 }
                 if (len < buflen) {
-                    if (isControlChar(c)) {  // don't insert control characters
+                    if (isControlChar(c) && !(c==ctrlChar('J'))) {  // don't insert control characters
                         beep();
                         break;
                     }

--- a/tst/example.c
+++ b/tst/example.c
@@ -28,7 +28,6 @@ int main () {
   printf("starting...\n");
 
   char const* prompt = "\x1b[1;32mlinenoise\x1b[0m> ";
-
   while (1) {
     char* result = linenoise(prompt);
 


### PR DESCRIPTION
Hi.

This is unpolished (although suits my own purposes) but I thought you might want to consider restoring the ctrl-enter functionality for entering multi-line entries.  At the moment I think you are missing one function from the original API: linenoiseSetMultiLine - which may become more useful again if this feature is restored.

The other suggestion is allowing user to press a defined key (maybe F2 as a default) to have enter just map to new line in the buffer and shift-enter complete the entry.  useful for a REPL to be able to copy and paste multi-line code (I am using with Lua).
