### PR TITLE
Basic bindkey functionality

### DIFF
--- a/include/linenoise.h
+++ b/include/linenoise.h
@@ -44,6 +44,8 @@
 extern "C" {
 #endif
 
+typedef void (lineNoiseBindkeyFunction)(void);
+
 typedef struct linenoiseCompletions linenoiseCompletions;
 
 typedef void(linenoiseCompletionCallback)(const char*, linenoiseCompletions*);
@@ -61,6 +63,8 @@ void linenoiseHistoryFree(void);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+int linenoiseBindkeyAdd(int key, lineNoiseBindkeyFunction *fn);
+int linenoiseBindkeyRemove(int key);
 /* the following is extension to the original linenoise API */
 int linenoiseInstallWindowChangeHandler(void);
 

--- a/src/linenoise.cpp
+++ b/src/linenoise.cpp
@@ -121,10 +121,12 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <memory>
 
 using std::string;
 using std::vector;
+using std::unordered_map;
 using std::unique_ptr;
 using namespace linenoise_ng;
 
@@ -913,6 +915,7 @@ static const int PAGE_DOWN_KEY = 0x11200000;
 
 static const char* unsupported_term[] = {"dumb", "cons25", "emacs", NULL};
 static linenoiseCompletionCallback* completionCallback = NULL;
+static unordered_map<int, lineNoiseBindkeyFunction *> bindKeyFunctions;
 
 #ifdef _WIN32
 static HANDLE console_in, console_out;
@@ -1766,6 +1769,7 @@ static char32_t linenoiseReadChar(void) {
     } else if (rec.Event.KeyEvent.uChar.UnicodeChar ==
                ctrlChar('[')) {  // ESC, set flag for later
       escSeen = true;
+      return modifierKeys | rec.Event.KeyEvent.uChar.UnicodeChar;
       continue;
     } else {
       // we got a real character, return it
@@ -1874,6 +1878,10 @@ static int cleanupCtrl(int c) {
     if (d >= ctrlChar('A') && d <= ctrlChar('Z')) {
       c = c & ~CTRL;
     }
+  }
+  auto found = bindKeyFunctions.find(c);
+  if (found != bindKeyFunctions.end()){
+    found->second();
   }
   return c;
 }
@@ -3362,5 +3370,25 @@ int linenoiseInstallWindowChangeHandler(void) {
     return errno;
   }
 #endif
+  return 0;
+}
+
+int linenoiseBindkeyAdd(int key, lineNoiseBindkeyFunction *fn)
+{ 
+  if (bindKeyFunctions.find(key) != bindKeyFunctions.end()){
+    // the key is already bound
+    return -1;
+  }
+  bindKeyFunctions.insert(std::make_pair(key, fn));
+  return 0; 
+}
+
+int linenoiseBindkeyRemove(int key)
+{
+  if (bindKeyFunctions.find(key) == bindKeyFunctions.end()){
+    // Key is not bound
+    return -1;
+  }
+  bindKeyFunctions.erase(key);
   return 0;
 }


### PR DESCRIPTION
Inspired in readline's rl_bind_key functionality.

So that in the application we can do something like:
```
	linenoiseBindkeyAdd(ctrlChar('T'), &f1);
	linenoiseBindkeyAdd(ctrlChar('X'), &f2);	
```
And call those functions when the keys are detected while in `linenoise()`