### PR TITLE
Update linenoise.cpp

### DIFF
--- a/src/linenoise.cpp
+++ b/src/linenoise.cpp
@@ -89,7 +89,7 @@
 #include <conio.h>
 #include <windows.h>
 #include <io.h>
-#if _MSC_VER < 1900
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf  // Microsoft headers use underscores in some names
 #endif
 #define strcasecmp _stricmp


### PR DESCRIPTION
I ran into trouble when trying to compile this under mingw64 (if you really want to know, I was compiling with rust-linenoise).

Basically, _snprintf was redefined and that caused an error. Now I'm able to compile...