### PR TITLE
Make installing conditional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,11 @@ add_library(
 )
 
 # install
-install(TARGETS linenoise DESTINATION lib)
-
-# headers
-install(FILES include/linenoise.h DESTINATION include)
+option(INSTALL_LINENOISE "Install linenoise" ON)
+if( INSTALL_LINENOISE )
+  install(TARGETS linenoise DESTINATION lib)
+  install(FILES include/linenoise.h DESTINATION include)
+endif()
 
 # build example
 add_executable(


### PR DESCRIPTION
This allows the user to specify if linenoise should
be installed at cmake configuration time. Defaults to ON,
i.e. no functional change.

Being able to disable installation is useful when linenoise
is used as a sub-project.